### PR TITLE
Mutable default parameters are unsafe

### DIFF
--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -115,7 +115,7 @@ class QuartApp(quart.Quart):
     def runx(self, /,
              host="0.0.0.0", port=None,
              debug=True, loop=None,
-             extra_files=set(),
+             extra_files=None,
              **kw):
         """Extended version of Quart.run()
 
@@ -128,6 +128,9 @@ class QuartApp(quart.Quart):
 
         # Default PORT is None, but it must be explicitly specified.
         assert port, "The port must be specified."
+
+        if extra_files is None: # mutable default parameters are unsafe, because they are instantiated once only
+            extra_files=set()
 
         # NOTE: much of the code below is direct from quart/app.py:Quart.run()
         # This local "copy" is to deal with the custom watcher/reloader.

--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -115,7 +115,7 @@ class QuartApp(quart.Quart):
     def runx(self, /,
              host="0.0.0.0", port=None,
              debug=True, loop=None,
-             extra_files=None,
+             extra_files=frozenset(),
              **kw):
         """Extended version of Quart.run()
 
@@ -128,9 +128,6 @@ class QuartApp(quart.Quart):
 
         # Default PORT is None, but it must be explicitly specified.
         assert port, "The port must be specified."
-
-        if extra_files is None: # mutable default parameters are unsafe, because they are instantiated once only
-            extra_files=set()
 
         # NOTE: much of the code below is direct from quart/app.py:Quart.run()
         # This local "copy" is to deal with the custom watcher/reloader.

--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -115,7 +115,7 @@ class QuartApp(quart.Quart):
     def runx(self, /,
              host="0.0.0.0", port=None,
              debug=True, loop=None,
-             extra_files=frozenset(),
+             extra_files=frozenset(), # OK, because immutable
              **kw):
         """Extended version of Quart.run()
 


### PR DESCRIPTION
Such parameters are only instantiated once, leading to possible pollution of subsequent calls