### PR TITLE
This updates the pyproject.toml file so that poetry can be used for deps

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,6 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.10", "3.11"]
-        poetry-version: ["1.8.3"]
     steps:
     - uses: actions/checkout@master
       with:
@@ -25,7 +24,6 @@ jobs:
       uses: packetcoders/action-setup-cache-python-poetry@v1.1.0
       with:
         python-version: ${{matrix.python-version}}
-        poetry-version: ${{matrix.poetry-version}}
     - name: Test with pytest
       run: |
         poetry run python3 -m pytest tests/*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,8 @@
-[build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
-
-[project]
+[tool.poetry]
 name = "asfquart"
 version = "0.1.5"
-authors = [ 
-  {name = "ASF Infrastructure", email = "users@infra.apache.org"}
-]
-dependencies = [
-    "aiohttp>=3.9.2",
-    "PyYAML>=6.0.1",
-    "pytest==7.2.0",
-    "pytest-cov>=4.0.0",
-    "pytest-asyncio>=0.20.3",
-    "pytest-mock>=3.10.0",
-    "quart>=0.19.4",
-    "ezt",
-    "asyncinotify",
-]
-license = {file = "LICENSE"}
+authors = ["ASF Infrastructure <users@infra.apache.org>"]
+license = "Apache-2.0"
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -27,7 +10,19 @@ classifiers = [
 ]
 description = "ASF Quart Framework"
 
-[project.optional-dependencies]
-ldap = [
-    "asfpy[aioldap]"
-]
+[tool.poetry.dependencies]
+python = "~3.10"
+aiohttp = "^3.9.2"
+PyYAML = "^6.0.1"
+pytest = "7.2.0"
+pytest-cov = "^4.0.0"
+pytest-asyncio = "^0.20.3"
+pytest-mock = "^3.10.0"
+quart = "^0.19.4"
+ezt = "~1.1"
+asyncinotify = "^4.0.9"
+asfpy = "~0.52"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I'm not sure I love this, but apparently poetry doesn't respect the `[project]` section of `pyproject.toml`. I have heard that poetry v2.0 will more fully implement PEP621 and therefore `[project]`, etc...