### PR TITLE
Sane defaults for cookies: SameSite=Strict; Secure; HttpOnly

### DIFF
--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -357,6 +357,11 @@ def construct(name, *args, **kw):
     # Provide our standard filename argument converter.
     import asfquart.utils
 
+    # Sane defaults for cookies: SameSite=Strict; Secure; HttpOnly
+    app.config["SESSION_COOKIE_SAMESITE"] = "Strict"
+    app.config["SESSION_COOKIE_SECURE"] = True
+    app.config["SESSION_COOKIE_HTTPONLY"] = True
+
     app.url_map.converters["filename"] = asfquart.utils.FilenameConverter
 
     # Set up oauth and login redirects if needed


### PR DESCRIPTION
This hard-sets three security options for cookies:
- SameSite=Strict (Cannot be used/initiated from 3rd party host)
- Secure=True (https only)
- HttpOnly (only the browser kernel can access the cookie contents)