### PR TITLE
Introduce a test dependency group and add useful badges to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # asfquart - a Quart framework for the ASF
-![Unit Tests](https://github.com/apache/infrastructure-asfquart/actions/workflows/unit-tests.yml/badge.svg)
-  
+![PyPI](https://img.shields.io/pypi/v/asfquart.svg?color=blue&maxAge=600)
+![PyPI - Python Versions](https://img.shields.io/pypi/pyversions/asfquart.svg?maxAge=600)
+![Unit Tests](https://github.com/apache/infrastructure-asfquart/actions/workflows/unit-tests.yml/badge.svg?branch=main)
+![Apache License](https://img.shields.io/github/license/apache/infrastructure-asfquart)
+
 This is a [Quart](https://github.com/pallets/quart/) framework for ASF web applications.
 
 On top of Quart, this package layers a lot of functionality, much of which is specific to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,24 +6,36 @@ license = "Apache-2.0"
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3"
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Environment :: Web Environment",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+    "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 description = "ASF Quart Framework"
+repository = "https://github.com/apache/infrastructure-asfquart"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
 aiohttp = "^3.9.2"
 PyYAML = "^6.0.1"
-pytest = "7.2.0"
-pytest-cov = "^4.0.0"
-pytest-asyncio = "^0.20.3"
-pytest-mock = "^3.10.0"
 quart = "^0.19.4"
 ezt = "~1.1"
 asfpy = "~0.52"
 easydict = "~1.13"
 exceptiongroup = { version = ">=1.1.0", python = "<3.11" }
 watchfiles = "~0.24.0"
+
+[tool.poetry.group.test.dependencies]
+pytest = "7.2.0"
+pytest-cov = "^4.0.0"
+pytest-asyncio = "^0.20.3"
+pytest-mock = "^3.10.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR adds 3 things:

- move all test related dependencies to a separate test dependency group
- add useful badges (current version on pypi, license, ..) to the README.md
- add more classifiers that seem to fit with the project

moving the test related dependencies to a separate group has the benefit that they are not declared as required dependencies when using asfquart as they shouldnt be required at runtime.