### PR TITLE
Update asfpy from 0.52 to 0.54

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ aiohttp = "^3.9.2"
 PyYAML = "^6.0.1"
 quart = "^0.20.0"
 ezt = "~1.1"
-asfpy = "~0.52"
+asfpy = "~0.54"
 easydict = "~1.13"
 exceptiongroup = { version = ">=1.1.0", python = "<3.11" }
-watchfiles = "~0.24.0"
+watchfiles = "~1.0.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "7.2.0"


### PR DESCRIPTION
This PR ensures that the `asfpy` dependency incorporates [commit 330b223](https://github.com/apache/infrastructure-asfpy/commit/330b223), which continues [the asfquart programme of replacing asyncinotify with watchfiles](https://github.com/apache/infrastructure-asfquart/commit/13d0dded6d0d926f1eb6534383837bc355f15d1c#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR4-R8). This also tracks the watchfiles [version upgrade](https://github.com/apache/infrastructure-asfpy/commit/6ea4eda) in `asfpy` to ensure that dependencies can be resolved.

On Linux, `poetry run pytest` succeeds with `5 passed, 2719 warnings in 4.59s`. On macOS, it fails with `1864 warnings, 3 errors in 1.91s`, three identical import errors each of which culminates in `_bonsai.cpython-313-darwin.so, 0x0002): symbol not found in flat namespace '_ldap_create_passwordpolicy_control'`.