### PR TITLE
Bump asfpy and watchfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,35 @@ if __name__ == "__main__":
 
 ~~~
 
-## Running unit tests for asfquart
+## Installation
 
-To run manually, use the following commands from the root dir of this repo:
+Create and activate a virtual environment and then install `asfquart` using [pip](https://pip.pypa.io):
 
-~~~shell
-poetry run pytest
-~~~
+```console
+$ pip install "asfquart"
+```
+
+Note: Adding the `[aioldap]` extra will install optional dependencies for LDAP support that will
+require additional [system dependencies](https://github.com/noirello/bonsai?tab=readme-ov-file#requirements-for-building):
+
+```console
+$ pip install "asfquart[aioldap]"
+```
+
+## Building asfquart package
+
+Prerequisites:
+
+- `poetry`: install e.g. with pipx `pipx install poetry`
+
+Building the package:
+
+```console
+$ poetry build
+```
+
+Running the tests:
+
+```console
+$ poetry run pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,14 @@ aiohttp = "^3.9.2"
 PyYAML = "^6.0.1"
 quart = "^0.20.0"
 ezt = "~1.1"
-asfpy = "~0.52"
+asfpy = "^0.55"
+bonsai = { version = "*", optional = true }
 easydict = "~1.13"
 exceptiongroup = { version = ">=1.1.0", python = "<3.11" }
-watchfiles = "~0.24.0"
+watchfiles = "~1.0.0"
+
+[tool.poetry.extras]
+aioldap = ["bonsai"]
 
 [tool.poetry.group.test.dependencies]
 pytest = "7.2.0"


### PR DESCRIPTION
This PR does the following changes:

 - bump asfpy dep to 0.55
 - add aioldap extra for ldap support from asfpy
 - bump watchfiles to the supported version range from asfpy
 - update README with information about installing / building the package