### PR TITLE
Disable merge commits

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,2 +1,7 @@
 github:
   del_branch_on_merge: true
+  # disable merge commits
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  true


### PR DESCRIPTION
Please take a look at this PR.

I would like to propose to disable merge commits as I personally prefer linear history.
I just merged a PR and did not notice that I merged with merge commit.

To prevent that from happening, this PR only enables squash or rebase as merge method.

If this change is not well received, I ofc respect that, its my personal preference though.