### PR TITLE
Support a runx method supporting a hypercorn config file

### DIFF
--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -192,8 +192,7 @@ class QuartApp(quart.Quart):
         """
 
         hypercorn_cfg_path = self.app_dir / hypercorn_cfg
-        config = hypercorn.Config()
-        config.from_toml(hypercorn_cfg_path)
+        config = hypercorn.Config.from_toml(hypercorn_cfg_path)
 
         if loop is None:
             loop = asyncio.new_event_loop()

--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -182,6 +182,8 @@ class QuartApp(quart.Quart):
                          ):
         """Extended version of Quart.run()
 
+        HYPERCORN_CFG is the hypercorn config file in toml format to use.
+
         LOOP is the loop this app should run within. One will be constructed,
         if this is not provided.
 
@@ -207,7 +209,7 @@ class QuartApp(quart.Quart):
 
         print(f' * Serving Quart app "{self.app_id}"')
         print(f" * Debug mode: {config.debug}")
-        print(f" * Using config: {hypercorn_cfg_path}")
+        print(f" * Using hypercorn config: {hypercorn_cfg}")
         print(f" * Running on {config.bind}")
         print(" * ... CTRL + C to quit")
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-
-import __main__
-
-# due to base.py#L80, to ensure that tests can be run within PyCharm
-delattr(__main__, "__file__")


### PR DESCRIPTION
This PR proposes the following changes:

- remove hack wrt `__main__.__file__` to determine the app dir
- support an `app_dir` kw arg to override the app directory if needed, defaults to the `cwd`
- pop asfquart specific kw args prior to calling `super.init` as quart panics otherwise
- add a `runx_from_config` method to support running hypercorn with a config file

That allows to run asfquart with a hypercorn config file to set various settings that would otherwise not be possible, e.g. `--reload`.