### PR TITLE
Cleanup application construction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: example-dev example-run
+
+example-dev:
+	@poetry run python3 examples/snippets/simple_app.py
+
+example-run:
+	@poetry run hypercorn examples.snippets.simple_app:app

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [documentation page](docs/readme.md) for more information.
 import asfquart
 from asfquart.auth import Requirements as R
 
-def my_app():
+def my_app() -> asfquart.base.QuartApp:
     # Construct the quart service. By default, the oauth gateway is enabled at /oauth.
     app = asfquart.construct("my_app_service")
 
@@ -55,13 +55,18 @@ def my_app():
     @asfquart.auth.require(R.committer)
     async def secret_page():
       return "Secret stuff!"
-    
-    asfquart.APP.run(port=8000)
 
+    return app
 
 if __name__ == "__main__":
-    my_app()
+    app = my_app()
 
+    # Run the application in an extended debug mode:
+    #  - reload the app when any source / config file get changed
+    app.runx(port=8000)
+else:
+    # Serve the application via an ASGI server, e.g. hypercorn
+    app = my_app()
 ~~~
 
 ## Installation
@@ -95,4 +100,19 @@ Running the tests:
 
 ```console
 $ poetry run pytest
+```
+
+## Examples
+
+There is a simple test application included (`./examples/snippets/simple_app.py`) to outline the basic setup.
+To run the application in development mode, type:
+
+```console
+$ make example-dev
+```
+
+to run it with an ASGI server for production, type:
+
+```console
+$ make example-run
 ```

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -13,9 +13,8 @@ import asfquart
 app = asfquart.construct("myapp", oauth="/my_oauth")
 
 # Make another app, but do not enable oauth nor force login redirect (implied by no oauth)
-otherapp = asfquart.construct("otherapp", oauth=None)
+otherapp = asfquart.construct("otherapp", oauth=False)
 
 # Make a third app, enable oauth at /auth, but do not force logins
 thirdapp = asfquart.construct("thirdapp", oauth="/auth", force_login=False)
 ~~~
-

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,6 +11,8 @@ def main():
 
 if __name__ == "__main__":
     app = main()
+    # run a development server on port 8080
+    app.runx(port=8080)
 ~~~
 
 Other modules in the app will use:

--- a/examples/snippets/simple_app.py
+++ b/examples/snippets/simple_app.py
@@ -8,9 +8,9 @@ import asfquart.session
 
 
 def my_app() -> asfquart.base.QuartApp:
-    # Construct the base app. The /oauth gateway is enabled by default.
+    # Construct the base app. The oauth gateway at endpoint '/auth' is enabled by default.
     # To disable it, use construct("my_app", oauth=False)
-    app = asfquart.construct("my_simple_app", cfg_file="config.yaml")
+    app = asfquart.construct("my_simple_app")
 
     # Default homepage
     @app.route("/")

--- a/examples/snippets/simple_app.py
+++ b/examples/snippets/simple_app.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     app = my_app()
 
     # Run the application in an extended debug mode:
-    #  - reload the app when any source / config file get changed
+    #  - reload the app when any source / config file gets changed
     app.runx(port=8000)
 else:
     # Serve the application via an ASGI server, e.g. hypercorn

--- a/examples/snippets/simple_app.py
+++ b/examples/snippets/simple_app.py
@@ -7,10 +7,10 @@ import asfquart.generics
 import asfquart.session
 
 
-def my_app():
+def my_app() -> asfquart.base.QuartApp:
     # Construct the base app. The /oauth gateway is enabled by default.
     # To disable it, use construct("my_app", oauth=False)
-    app = asfquart.construct("my_simple_app")
+    app = asfquart.construct("my_simple_app", cfg_file="config.yaml")
 
     # Default homepage
     @app.route("/")
@@ -26,8 +26,17 @@ def my_app():
     # Authentication failures redirect to login flow.
     asfquart.generics.enforce_login(app)
 
-    app.run(port=8000)
+    # Print some message to indicate that the application has been loaded.
+    print(f"Loaded app '{app.name}'.")
+    return app
 
 
 if __name__ == "__main__":
-    my_app()
+    app = my_app()
+
+    # Run the application in an extended debug mode:
+    #  - reload the app when any source / config file get changed
+    app.runx(port=8000)
+else:
+    # Serve the application via an ASGI server, e.g. hypercorn
+    app = my_app()

--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -68,7 +68,7 @@ class ASFQuartException(Exception):
 class QuartApp(quart.Quart):
     """Subclass of quart.Quart to include our specific features."""
 
-    def __init__(self, app_id: str, /, app_dir: str | None = None, cfg_file: str | None = CONFIG_FNAME, *args, **kw):
+    def __init__(self, app_id: str, /, app_dir: str | None = None, cfg_file: str | None = None, *args, **kw):
         """Construct an ASFQuart web application.
 
         Arguments:
@@ -80,7 +80,7 @@ class QuartApp(quart.Quart):
 
         self.app_id = app_id
         self.app_dir = pathlib.Path(app_dir or os.getcwd())
-        self.cfg_path = self.app_dir / cfg_file
+        self.cfg_path = self.app_dir / (cfg_file or CONFIG_FNAME)
 
         # Most apps will require a watcher for their EZT templates.
         self.tw = asfpy.twatcher.TemplateWatcher()
@@ -337,7 +337,7 @@ def construct(
     name: str,
     /,
     app_dir: str | None = None,
-    cfg_file: str | None = CONFIG_FNAME,
+    cfg_file: str | None = None,
     oauth: bool | str = True,
     force_login: bool = True,
     *args,

--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -37,7 +37,6 @@ import yaml
 import watchfiles
 
 from . import utils
-from . import config
 
 try:
     ExceptionGroup
@@ -68,7 +67,6 @@ class ASFQuartException(Exception):
 
 class QuartApp(quart.Quart):
     """Subclass of quart.Quart to include our specific features."""
-    config_class = config.ASFQuartConfig
 
     def __init__(self, app_id: str, /, app_dir: str | None = None, cfg_file: str | None = CONFIG_FNAME, *args, **kw):
         """Construct an ASFQuart web application.
@@ -89,7 +87,6 @@ class QuartApp(quart.Quart):
         self.add_runner(self.tw.watch_forever, name=f"TW:{app_id}")
 
         # use an easydict for config values
-        # FIXME: this is deprecated, use config instead
         self.cfg = easydict.EasyDict()
 
         # token handler callback for PATs - see docs/sessions.md
@@ -378,11 +375,7 @@ def construct(
 
     # try to load the config information from app.cfg_path
     if os.path.isfile(app.cfg_path):
-        config_values = yaml.safe_load(open(app.cfg_path))
-        app.config.update(config_values)
-
-        # FIXME: this is deprecated, app.cfg should be removed in favor of app.config
-        app.cfg.update(config_values)
+        app.cfg.update(yaml.safe_load(open(app.cfg_path)))
 
     # Provide our standard filename argument converter.
     import asfquart.utils

--- a/src/asfquart/config.py
+++ b/src/asfquart/config.py
@@ -10,10 +10,6 @@ import quart.config
 DEFAULT_CONFIG_FILENAME = "config.yaml"
 
 
-class ASFQuartConfig(quart.config.Config, easydict.EasyDict):
-    pass
-
-
 async def _read_config(callback, config_filename):
     """Reads a YAML configuration and passes it to the callback"""
     with open(config_filename, encoding='utf-8') as r:

--- a/src/asfquart/config.py
+++ b/src/asfquart/config.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 
 """ASFQuart - Configuration readers"""
-
+import easydict
 import yaml
 import functools
 import inspect
+import quart.config
 
 DEFAULT_CONFIG_FILENAME = "config.yaml"
+
+
+class ASFQuartConfig(quart.config.Config, easydict.EasyDict):
+    pass
 
 
 async def _read_config(callback, config_filename):

--- a/src/asfquart/config.py
+++ b/src/asfquart/config.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 
 """ASFQuart - Configuration readers"""
-import easydict
 import yaml
 import functools
 import inspect
-import quart.config
 
 DEFAULT_CONFIG_FILENAME = "config.yaml"
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-
-import __main__
-
-# due to base.py#L80, to ensure that tests can be run within PyCharm
-delattr(__main__, "__file__")


### PR DESCRIPTION
This PR does the following changes:

 - removes hack wrt hypercorn and `__file__` parameter. Also hypercorn now only loads the application in the worker process, see https://github.com/pgjones/hypercorn/pull/143
 - update simple example app
 - add Makefile to showcase how the example app can be started in development and ASGI mode
 - update README