### PR TITLE
Converting asserts to error handling

### DIFF
--- a/src/asfquart/base.py
+++ b/src/asfquart/base.py
@@ -163,7 +163,8 @@ class QuartApp(quart.Quart):
         """
 
         # Default PORT is None, but it must be explicitly specified.
-        assert port, "The port must be specified."
+        if not port:
+            raise ValueError("The port must be specified.")
 
         # NOTE: much of the code below is direct from quart/app.py:Quart.run()
         # This local "copy" is to deal with the custom watcher/reloader.

--- a/src/asfquart/generics.py
+++ b/src/asfquart/generics.py
@@ -81,7 +81,8 @@ def setup_oauth(app, uri=DEFAULT_OAUTH_URI, workflow_timeout: int = 900):
                 ct = aiohttp.client.ClientTimeout(sock_read=15)
                 async with aiohttp.client.ClientSession(timeout=ct) as session:
                     rv = await session.get(OAUTH_URL_CALLBACK % code)
-                    assert rv.status == 200, "Could not verify oauth response."
+                    if rv.status != 200:
+                        return quart.Response(status=403, response="OAuth authentication failed.\n")
                     oauth_data = await rv.json()
                     asfquart.session.write(oauth_data)
                 if redirect_uri:  # if called with /auth=login=/foo, redirect to /foo

--- a/src/asfquart/session.py
+++ b/src/asfquart/session.py
@@ -69,7 +69,8 @@ async def read(expiry_time=86400*7, app=None) -> typing.Optional[ClientSession]:
         match quart.request.authorization.type:
             case "bearer":  # Role accounts, PATs - TBD
                 if app.token_handler:
-                    assert callable(app.token_handler), "app.token_handler is not a callable function!"
+                    if not callable(app.token_handler):
+                        raise TypeError("app.token_handler is not a callable function.")
                     session_dict = None  # Blank, in case we don't have a working callback.
                     # Async token handler?
                     if asyncio.iscoroutinefunction(app.token_handler):


### PR DESCRIPTION
# Replace `assert` statements with explicit error handling

Fixes #54 

**Source:** V10.4.2 audit — Observation 2
**Severity:** Low
**Files changed:** `src/asfquart/generics.py`, `src/asfquart/session.py`, `src/asfquart/base.py`

## Summary

Three `assert` statements in the asfquart source code have been replaced with explicit error handling. Python's `assert` statements are stripped entirely when the interpreter runs with the `-O` (optimize) flag, meaning all three of these checks would be silently skipped under that condition. While running with `-O` in production is uncommon, relying on `assert` for runtime validation violates defense-in-depth principles — particularly in authentication-critical code paths.

Beyond the `-O` bypass risk, the previous behavior was also incorrect even under normal execution: a failed `assert` raises an unhandled `AssertionError` that bypasses the app's own `ASFQuartException` error handler, resulting in a generic 500 Internal Server Error with a raw traceback instead of a meaningful, appropriate HTTP response.

## Changes

### 1. `generics.py` — OAuth token exchange (line 84)

**Previous behavior:**
```python
assert rv.status == 200, "Could not verify oauth response."
```
If the upstream OAuth server returned a non-200 status (e.g. a rejected or malicious token exchange), the `AssertionError` would bubble up unhandled and Quart would return a **500 Internal Server Error** to the client. This is misleading — the failure is an authentication problem (4xx), not an internal server error. Under `-O`, the check would be skipped entirely, allowing the OAuth flow to proceed with a failed response and attempt to parse and store potentially invalid or malicious data as a user session.

**New behavior:**
```python
if rv.status != 200:
    return quart.Response(status=403, response="OAuth authentication failed.\n")
```
The client now receives a clear **403 Forbidden** that accurately communicates the authentication failure. The check cannot be bypassed by `-O`, and the response is consistent with the 403 already used for expired/invalid OAuth states earlier in the same function.

---

### 2. `session.py` — Token handler callable validation (line 72)

**Previous behavior:**
```python
assert callable(app.token_handler), "app.token_handler is not a callable function!"
```
If `app.token_handler` was set to a truthy but non-callable value, the `AssertionError` would surface as an unhandled **500** to the client, bypassing the app's `ASFQuartException` handler. Under `-O`, the check would be skipped — the subsequent `callable()` guard at line 78 would return `False`, `session_dict` would remain `None`, and bearer token authentication would silently fail to establish a session rather than raising a clear configuration error.

**New behavior:**
```python
if not callable(app.token_handler):
    raise TypeError("app.token_handler is not a callable function!")
```
A `TypeError` is the idiomatic Python exception for calling something that isn't callable. This makes the misconfiguration immediately visible in logs and cannot be stripped by `-O`.

---

### 3. `base.py` — Port validation in `runx()` (line 166)

**Previous behavior:**
```python
assert port, "The port must be specified."
```
A missing port at startup would raise an `AssertionError` with a traceback. Under `-O`, the check would be skipped and the app would attempt to bind to `None`, producing a confusing error deeper in the networking stack.

**New behavior:**
```python
if not port:
    raise ValueError("The port must be specified.")
```
`ValueError` is the standard Python exception for an invalid argument. The error message is clear and immediate, and process supervisors or tooling that inspect exception types will handle it predictably.

## Testing

All 19 existing tests pass. Note that none of the three modified code paths had existing test coverage — the generics tests cover login initiation and redirect validation but not the OAuth callback token exchange, the session tests cover cookie-based sessions but not bearer token auth, and there are no tests for `runx()` startup validation. Adding targeted tests for these error paths would be a worthwhile follow-up.

## Rebase

```
$ git fetch upstream main
From github.com:apache/infrastructure-asfquart
 * branch            main       -> FETCH_HEAD
$ git rebase upstream/main
Current branch handle-errors-54 is up to date.
```